### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ leveldb: $(LEVELDBPATH)
 	make -C $(LEVELDBPATH)
 
 $(BIN): $(DEPS) $(LIBPATH)/*.cc deps/docopt
-	$(CXX) -o $(BIN) $(SRC) $(CXXFLAGS) -lpthread -L/usr/local/include $(LIBLEVELDB) $(DEPS)
+	$(CXX) -o $(BIN) $(SRC) $(CXXFLAGS) -lpthread -L/usr/local/lib -lsnappy $(LIBLEVELDB) $(DEPS)
 
 deps/snappy:
 	git clone --depth 1 https://github.com/0x00A/snappy ./deps/snappy


### PR DESCRIPTION
What I did:
* Fixed path for `-L`.
* Added `-lsnappy`.

What you also may want to do:
* trigger targets `deps/snappy` and ` snappy.o` as well; I had to do this manually.

The current `Makefile` can never have worked - would be nice to test it before release 😉  