### PR TITLE
Add get_bin command to retrieve binary data without trailing \n

### DIFF
--- a/ldb.cc
+++ b/ldb.cc
@@ -52,7 +52,7 @@ R"(ldb
 
     Usage:
       ldb <path> [--create] [--error] [--size] [--nocompress]
-      ldb <path> (del|get) <key>
+      ldb <path> (del|get|getbin) <key>
       ldb <path> put <key> <value> [--nocompress]
       ldb <path> keys [--limit=<n>] [--lower=<lower>] [--upper=<upper>]
       ldb (-h | --help)
@@ -106,6 +106,7 @@ int main(int argc, const char** argv)
   if (args["del"].asBool() ||
       args["put"].asBool() ||
       args["get"].asBool() ||
+      args["getbin"].asBool() ||
       args["keys"].asBool() ||
       args["--size"].asBool()) {
     interactive = false;
@@ -144,6 +145,9 @@ int main(int argc, const char** argv)
 
   if (args["get"] && args["get"].asBool()) {
     ldb::get_value(args["<key>"].asString());
+  }
+  else if (args["getbin"] && args["getbin"].asBool()) {
+    ldb::get_value_bin(args["<key>"].asString());
   }
   else if (args["put"] && args["put"].asBool()) {
 

--- a/ldb.h
+++ b/ldb.h
@@ -66,6 +66,7 @@ namespace ldb {
   void auto_completion(const char *buf, linenoiseCompletions *lc);
   void put_value(string key, string value);
   void get_value(string key);
+  void get_value_bin(string key);
   void del_value(string key);
   void get_size();
   void range(string prefix, bool surpress_output);

--- a/lib/commands.cc
+++ b/lib/commands.cc
@@ -42,6 +42,19 @@ void ldb::get_value(string key) {
   }
 }
 
+void ldb::get_value_bin(string key) {
+  if (key == "") return;
+
+  string value;
+  leveldb::Status status = db->Get(leveldb::ReadOptions(), key, &value);
+
+  if (!status.ok()) {
+    cerr << "Not Found: [" << COLOR_BLUE << key << COLOR_NONE << "]" << endl;
+  } else {
+    cout << value;
+  }
+}
+
 //
 //
 //


### PR DESCRIPTION
I'm not sure if this is a correct implementation.
Related to #52.