### PR TITLE
fix leveldb missing Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ export CXXFLAGS
 all: leveldb $(BIN)
 
 $(LEVELDBPATH):
-	git clone --depth 1 https://github.com/google/leveldb $(LEVELDBPATH)
+	git clone --depth 1 --single-branch --branch v1.20 https://github.com/google/leveldb $(LEVELDBPATH)
 leveldb: $(LEVELDBPATH)
 	make -C $(LEVELDBPATH)
 


### PR DESCRIPTION
LevelDB recently switched to CMake, effectively removing the existing Makefile from the master branch
ref: https://github.com/google/leveldb/commit/8e75db8623703cdc25ec3cd06f82129296672489

fixes #56 