### PR TITLE
use CMake to build LevelDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ LIBPATH ?= ./lib
 SRC = ldb.cc $(LIBPATH)/*.cc ./deps/docopt/docopt.cpp
 PREFIX ?= /usr/local
 LEVELDBPATH ?= ./deps/leveldb
-LIBLEVELDB ?= $(LEVELDBPATH)/out-static/libleveldb.a
+LEVELDBBUILD ?= ./deps/leveldb/build
+LIBLEVELDB ?= $(LEVELDBBUILD)/libleveldb.a
 LIBSNAPPY ?= ./deps/snappy
 CXXFLAGS += -I$(LEVELDBPATH)/include -std=gnu++11
 
@@ -25,7 +26,8 @@ all: leveldb $(BIN)
 $(LEVELDBPATH):
 	git clone --depth 1 https://github.com/google/leveldb $(LEVELDBPATH)
 leveldb: $(LEVELDBPATH)
-	make -C $(LEVELDBPATH)
+	cmake -DCMAKE_BUILD_TYPE=Release -B$(LEVELDBBUILD) -H$(LEVELDBPATH) && \
+	cmake --build $(LEVELDBBUILD)
 
 $(BIN): $(DEPS) $(LIBPATH)/*.cc deps/docopt
 	$(CXX) -o $(BIN) $(SRC) $(CXXFLAGS) -lpthread -L/usr/local/lib -lsnappy $(LIBLEVELDB) $(DEPS)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A c++ repl and cli tool for leveldb
 ## Mac OS X
 
 ```cli
-$ brew install snappy
+$ brew install snappy cmake
 $ git clone https://github.com/0x00a/ldb.git
 $ make install -C ldb
 ```
@@ -16,7 +16,7 @@ $ make install -C ldb
 ## Linux (Debian / others?)
 
 ```cli
-$ apt-get install libsnappy-dev
+$ apt-get install libsnappy-dev cmake
 $ git clone https://github.com/0x00a/ldb.git
 $ sudo make install
 ```


### PR DESCRIPTION
LevelDB now requires CMake to build the sources (https://github.com/google/leveldb/commit/739c25100e46576cdcdfff2d6f43f9f7008103c7)

follow-up of #57, fixes #56 